### PR TITLE
Add install command to community-node CLI

### DIFF
--- a/packages/cli/src/commands/__tests__/community-node.test.ts
+++ b/packages/cli/src/commands/__tests__/community-node.test.ts
@@ -241,7 +241,7 @@ describe('uninstallPackage', () => {
 		expect(removeCommunityPackageSpy).toHaveBeenCalledTimes(0);
 	});
 
-	it('should return if nodes are not found', async () => {
+        it('should return if nodes are not found', async () => {
 		const communityPackage = {
 			installedNodes: [],
 		};
@@ -263,9 +263,56 @@ describe('uninstallPackage', () => {
 		expect(deleteCommunityNode).toHaveBeenCalledTimes(0);
 
 		expect(removeCommunityPackageSpy).toHaveBeenCalledTimes(1);
-		expect(removeCommunityPackageSpy).toHaveBeenCalledWith(
-			'n8n-nodes-evolution-api',
-			communityPackage,
-		);
-	});
+                expect(removeCommunityPackageSpy).toHaveBeenCalledWith(
+                        'n8n-nodes-evolution-api',
+                        communityPackage,
+                );
+        });
+});
+
+describe('installPackage', () => {
+       const config: Config = mock<Config>();
+       const communityNode = new CommunityNode(
+               ['--install', '--package', 'n8n-nodes-test'],
+               config,
+       );
+
+       beforeEach(() => {
+               communityNode.installPackage = jest.fn();
+       });
+
+       afterEach(() => {
+               jest.resetAllMocks();
+       });
+
+       it('should install the package', async () => {
+               communityNode.parseFlags = jest.fn().mockReturnValue({
+                       flags: { package: 'n8n-nodes-test', install: true },
+               });
+
+               const installPackage = jest.spyOn(communityNode, 'installPackage');
+
+               await communityNode.run();
+
+               expect(installPackage).toHaveBeenCalledTimes(1);
+               expect(installPackage).toHaveBeenCalledWith('n8n-nodes-test', false, undefined);
+       });
+
+       it('should install the package with verify and version', async () => {
+               communityNode.parseFlags = jest.fn().mockReturnValue({
+                       flags: {
+                               package: 'n8n-nodes-test',
+                               install: true,
+                               verify: true,
+                               version: '0.2.0',
+                       },
+               });
+
+               const installPackage = jest.spyOn(communityNode, 'installPackage');
+
+               await communityNode.run();
+
+               expect(installPackage).toHaveBeenCalledTimes(1);
+               expect(installPackage).toHaveBeenCalledWith('n8n-nodes-test', true, '0.2.0');
+       });
 });

--- a/packages/cli/src/commands/community-node.ts
+++ b/packages/cli/src/commands/community-node.ts
@@ -5,29 +5,40 @@ import { Flags } from '@oclif/core';
 
 import { CredentialsService } from '@/credentials/credentials.service';
 import { CommunityPackagesService } from '@/services/community-packages.service';
+import { CommunityNodeTypesService } from '@/services/community-node-types.service';
 
 import { BaseCommand } from './base-command';
 
 export class CommunityNode extends BaseCommand {
-	static description = '\nUninstall a community node and its credentials';
+       static description = '\nInstall or uninstall a community node and its credentials';
 
 	static examples = [
-		'$ n8n community-node --uninstall --package n8n-nodes-evolution-api',
-		'$ n8n community-node --uninstall --credential evolutionApi --userId 1234',
+               '$ n8n community-node --install --package n8n-nodes-evolution-api',
+               '$ n8n community-node --uninstall --package n8n-nodes-evolution-api',
+               '$ n8n community-node --uninstall --credential evolutionApi --userId 1234',
 	];
 
 	static flags = {
 		help: Flags.help({ char: 'h' }),
-		uninstall: Flags.boolean({
-			description: 'Uninstalls the node',
-		}),
-		package: Flags.string({
-			description: 'Package name of the community node.',
-		}),
-		credential: Flags.string({
-			description:
-				"Type of the credential.\nGet this value by visiting the node's .credential.ts file and getting the value of `name`",
-		}),
+               uninstall: Flags.boolean({
+                       description: 'Uninstalls the node',
+               }),
+               install: Flags.boolean({
+                       description: 'Installs the node',
+               }),
+               package: Flags.string({
+                       description: 'Package name of the community node.',
+               }),
+               version: Flags.string({
+                       description: 'Version of the community node package',
+               }),
+               verify: Flags.boolean({
+                       description: 'Only install if the package is vetted',
+               }),
+               credential: Flags.string({
+                       description:
+                               "Type of the credential.\nGet this value by visiting the node's .credential.ts file and getting the value of `name`",
+               }),
 		userId: Flags.string({
 			description:
 				'The ID of the user who owns the credential.\nOn self-hosted, query the database.\nOn cloud, query the API with your API key',
@@ -41,29 +52,49 @@ export class CommunityNode extends BaseCommand {
 	async run() {
 		const { flags } = await this.parseFlags();
 
-		const packageName = flags.package;
-		const credentialType = flags.credential;
-		const userId = flags.userId;
+               const packageName = flags.package;
+               const credentialType = flags.credential;
+               const userId = flags.userId;
+               const verify = Boolean(flags.verify);
+               const version = flags.version;
 
-		if (!flags) {
-			this.logger.info('Please set flags. See help for more information.');
-			return;
-		}
+               const install = flags.install;
+               const uninstall = flags.uninstall;
 
-		if (!flags.uninstall) {
-			this.logger.info('"--uninstall" has to be set!');
-			return;
-		}
+               if (!flags) {
+                       this.logger.info('Please set flags. See help for more information.');
+                       return;
+               }
 
-		if (!packageName && !credentialType) {
-			this.logger.info('"--package" or "--credential" has to be set!');
-			return;
-		}
+               if (!install && !uninstall) {
+                       this.logger.info('"--install" or "--uninstall" has to be set!');
+                       return;
+               }
 
-		if (packageName) {
-			await this.uninstallPackage(packageName);
-			return;
-		}
+               if (install && uninstall) {
+                       this.logger.info('Please specify only one of "--install" or "--uninstall"');
+                       return;
+               }
+
+               if (uninstall && !packageName && !credentialType) {
+                       this.logger.info('"--package" or "--credential" has to be set!');
+                       return;
+               }
+
+               if (install && !packageName) {
+                       this.logger.info('"--package" has to be set!');
+                       return;
+               }
+
+               if (install && packageName) {
+                       await this.installPackage(packageName, verify, version);
+                       return;
+               }
+
+               if (uninstall && packageName) {
+                       await this.uninstallPackage(packageName);
+                       return;
+               }
 
 		if (credentialType && userId) {
 			await this.uninstallCredential(credentialType, userId);
@@ -111,8 +142,8 @@ export class CommunityNode extends BaseCommand {
 		return await Container.get(CredentialsService).delete(user, credentialId);
 	}
 
-	async uninstallPackage(packageName: string) {
-		const communityPackage = await this.findCommunityPackage(packageName);
+        async uninstallPackage(packageName: string) {
+                const communityPackage = await this.findCommunityPackage(packageName);
 
 		if (communityPackage === null) {
 			this.logger.info(`Package ${packageName} not found`);
@@ -132,8 +163,33 @@ export class CommunityNode extends BaseCommand {
 			await this.deleteCommunityNode(node);
 		}
 
-		await this.pruneDependencies();
-	}
+                await this.pruneDependencies();
+        }
+
+       async installPackage(packageName: string, verify: boolean, version?: string) {
+               let checksum: string | undefined;
+
+               if (verify) {
+                       const vetted = Container.get(CommunityNodeTypesService).findVetted(packageName);
+                       if (!vetted) {
+                               this.logger.info(`Package ${packageName} is not vetted for installation`);
+                               return;
+                       }
+                       checksum = vetted.checksum;
+               }
+
+               try {
+                       await Container.get(CommunityPackagesService).installPackage(
+                               packageName,
+                               version,
+                               checksum,
+                       );
+                       this.logger.info(`Package ${packageName} installed successfully`);
+               } catch (error) {
+                       this.logger.error('Failed to install package');
+                       if (error instanceof Error) this.logger.error(error.message);
+               }
+       }
 
 	async pruneDependencies() {
 		await Container.get(CommunityPackagesService).executeNpmCommand('npm prune');


### PR DESCRIPTION
## Summary
- add install flag and options to community-node CLI
- implement installation logic using CommunityPackagesService
- extend tests for new install command

## Testing
- `pnpm test --filter n8n` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684163a0bec88326b5007d1c1f5c6042